### PR TITLE
Find meeting branch

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package com.google.sps;
 
 import java.util.Collection;

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -15,9 +15,73 @@
 package com.google.sps;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
+    List<TimeRange> availableTimes = new ArrayList<TimeRange>();
+    List<TimeRange> unavailableTimes = new ArrayList<TimeRange>();
+
+    for (Event e : events) {
+        if (!attendeesFree(e, request)) {
+            unavailableTimes.add(e.getWhen());
+        }
+    }
+
+    Collections.sort(unavailableTimes, TimeRange.ORDER_BY_START);
+
+    if (unavailableTimes.size() > 0) {
+        combineOverlaps(unavailableTimes, unavailableTimes.get(0), 0);
+    }
+
+    int start = 0;
+    for (TimeRange range : unavailableTimes) {
+        TimeRange availableRange = TimeRange.fromStartEnd(start, range.start(), false);
+
+        addAvailableRanges(availableTimes, availableRange, request);
+        
+        start = range.end();
+    }
+
+    TimeRange lastAvailableRange = TimeRange.fromStartEnd(start, TimeRange.END_OF_DAY+1, false);
+
+    addAvailableRanges(availableTimes, lastAvailableRange, request);
+    
+    return availableTimes;   
+  }
+ 
+  public boolean attendeesFree(Event e, MeetingRequest request){
+    return Collections.disjoint(e.getAttendees(), request.getAttendees());
+  }
+
+  public void addAvailableRanges(List<TimeRange> availableTimes, TimeRange range, MeetingRequest request){
+    if (range.start() < range.end() && range.duration() >= request.getDuration()) {
+        availableTimes.add(range);
+    }
+  }
+
+  public void combineOverlaps(List<TimeRange> unavailableTimes, TimeRange previous, int index){
+    if (index > unavailableTimes.size()-1) {
+        return;
+    }
+
+    TimeRange current = unavailableTimes.get(index);
+
+    if (current.overlaps(previous)) {
+        TimeRange earlierRange = (current.start() < previous.start()) ? current : previous;
+        TimeRange laterRange = (current.end() > previous.end()) ? current : previous;
+        TimeRange combinedRange = TimeRange.fromStartEnd(earlierRange.start(), laterRange.end(), false);
+        int initialIndex = unavailableTimes.indexOf(previous);
+
+        unavailableTimes.remove(previous);
+        unavailableTimes.remove(current);
+        unavailableTimes.add(initialIndex, combinedRange);
+
+        combineOverlaps(unavailableTimes, combinedRange, initialIndex + 1);
+    }
+
+    combineOverlaps(unavailableTimes, current, index + 1);
   }
 }


### PR DESCRIPTION
-Parses list of total events for the day to find which events involve the required attendees
-Forms list of all events that involve the required attendees
-Stores the time slots between those events as available times to host a meetings since no required attendees are busy during those times
-Combines overlapping events into a larger event to make it easier to analyze